### PR TITLE
Move from Docker Hub to GitHub Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,39 +26,23 @@ To build for more than one platform, multiple `--image` arguments may be passed:
 prebuildify-cross -i linux-armv7 -i linux-arm64 -t ..
 ```
 
-Lastly, it's possible to use your own custom image with e.g. `-i my-namespace/my-image`.
+By default [`prebuild/docker-images`](https://github.com/prebuild/docker-images) are used which are publicly hosted on the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`). It's possible to use custom images with e.g. `-i my-namespace/my-image`. Image arguments that don't contain a forward slash are expanded to `ghcr.io/prebuild/<image>` and if these don't contain a tag they're further expanded to `ghcr.io/prebuild/<image>:<version>` where `version` is currently 1.
+
+To use `latest` images (not recommended) an image tag must be specified explicitly. For example:
+
+```
+prebuildify-cross -i linux-armv7:latest -t ..
+```
 
 ## Images
 
-### `centos7-devtoolset7`
-
-Compile in CentOS 7, as a better alternative to (commonly) Ubuntu 16.04 on Travis. Makes the prebuild compatible with Debian 8, Ubuntu 14.04, RHEL 7, CentOS 7 and other Linux flavors with an old glibc.
-
-> The neat thing about this is that you get to compile with gcc 7 but glibc 2.17, so binaries are compatible for \[among others] Ubuntu 14.04 and Debian 8.
->
-> The RHEL folks put in a ton of work to make the devtoolsets work on their older base systems (libc mainly), which involves shipping a delta library that contains the new stuff that can be statically linked in where it's used. We use this method for building Node binary releases.
->
-> \-- <cite>[**@rvagg**](https://github.com/rvagg) ([prebuild/docker-images#8](https://github.com/prebuild/docker-images/pull/8))</cite>
-
-By default the prebuild will be [tagged](https://github.com/prebuild/prebuildify#options) with the libc flavor to set it apart from Alpine prebuilds, e.g. `linux-x64/node.libc.node`.
-
-### `alpine`
-
-Compile in Alpine, which uses musl instead of glibc and therefore can't run regular linux prebuilds. Worse, it sometimes does successfully _load_ such a  prebuild during `npm install` - which prevents a compilation fallback from kicking in - and then segfaults at runtime. You can fix this situation in two ways: by shipping an `alpine` prebuild and/or by shipping a `centos7-devtoolset7` prebuild, because the latter will be skipped in Alpine thanks to the `libc` tag.
-
-By default the prebuild will be [tagged](https://github.com/prebuild/prebuildify#options) with the libc flavor, e.g. `linux-x64/node.musl.node`.
-
-### `linux-armv7` and `linux-arm64`
-
-Cross-compile for Linux ARM. These images thinly wrap [`dockcross`](https://github.com/dockcross/dockcross) images.
-
-By default the prebuild will be [tagged](https://github.com/prebuild/prebuildify#options) with the armv version (7 or 8, respectively).
-
-### `android-armv7` and `android-arm64`
-
-Cross-compile for Android ARM. These images thinly wrap [`dockcross`](https://github.com/dockcross/dockcross) images.
-
-By default the prebuild will be [tagged](https://github.com/prebuild/prebuildify#options) with the armv version (7 or 8, respectively).
+- [`centos7-devtoolset7`](https://github.com/prebuild/docker-images#centos7-devtoolset7)
+- [`alpine`](https://github.com/prebuild/docker-images#alpine)
+- [`linux-armv6`](https://github.com/prebuild/docker-images#linux-armv6)
+- [`linux-armv7`](https://github.com/prebuild/docker-images#linux-armv7)
+- [`linux-arm64`](https://github.com/prebuild/docker-images#linux-arm64)
+- [`android-armv7`](https://github.com/prebuild/docker-images#android-armv7)
+- [`android-arm64`](https://github.com/prebuild/docker-images#android-arm64)
 
 ## References
 

--- a/guest.js
+++ b/guest.js
@@ -25,7 +25,7 @@ for (const file of files) {
 fs.symlinkSync('/input/node_modules', path.join(cwd, 'node_modules'))
 
 const stdio = ['ignore', 2, 2]
-const res = cp.spawnSync('npx', ['prebuildify', ...argv], { cwd, stdio })
+const res = cp.spawnSync('npx', ['--no-install', 'prebuildify', ...argv], { cwd, stdio })
 
 if (res.status) process.exit(res.status)
 if (res.error) throw res.error

--- a/index.js
+++ b/index.js
@@ -31,7 +31,16 @@ module.exports = function (opts, callback) {
   function loop () {
     let image = images.shift()
     if (!image) return process.nextTick(callback)
-    if (!image.includes('/')) image = 'prebuild/' + image
+
+    // Default to images from https://github.com/prebuild/docker-images
+    if (!image.includes('/')) {
+      image = 'ghcr.io/prebuild/' + image
+
+      // Pin to version 1 by default
+      if (!image.includes(':')) {
+        image = image + ':1'
+      }
+    }
 
     dockerPull(image)
       .on('progress', progress)
@@ -118,9 +127,9 @@ function prebuildifyArgv (argv, image) {
     }
   }
 
-  // TODO: move this to the docker images?
-  if (/^prebuild\/(linux|android)-arm/.test(image)) argv.push('--tag-armv')
-  if (/^prebuild\/(centos|alpine)/.test(image)) argv.push('--tag-libc')
+  // TODO: move this to the docker images (https://github.com/prebuild/docker-images/issues/11)
+  if (/^(ghcr\.io\/)?prebuild\/(linux|android)-arm/.test(image)) argv.push('--tag-armv')
+  if (/^(ghcr\.io\/)?prebuild\/(centos|alpine)/.test(image)) argv.push('--tag-libc')
 
   return argv
 }

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = function (opts, callback) {
       .pipe(child.stdin)
 
     child.stderr
-      .pipe(process.stderr)
+      .pipe(process.stderr, { end: false })
 
     child.stdout
       .pipe(tar.extract(prebuilds), { dmode: 0o755, fmode: 0o644 })

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const packlist = require('npm-packlist')
 const tar = require('tar-fs')
-const dockerPull = require('docker-pull')
+const dockerPull = require('@vweevers/docker-pull')
 const dockerRun = require('docker-run')
 const logger = require('log-update')
 const bytes = require('pretty-bytes')

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "standard"
   },
   "dependencies": {
+    "@vweevers/docker-pull": "^1.1.1",
     "browserify": "^16.5.0",
-    "docker-pull": "^1.1.0",
     "docker-run": "^3.1.0",
     "log-update": "^3.3.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Depends on prebuild/docker-images#19. Effectively fixes a critical bug (prebuild/docker-images#17) for dockcross-based images. Those are:

- `linux-armv6`
- `linux-armv7`
- `linux-arm64`
- `android-armv7`
- `android-arm64`

Also pins image versions (to version 1) by default, which is now possible because the images are tagged with version numbers in addition to the `latest` tag.

Image descriptions have moved to the `prebuild/docker-images` repository.