### PR TITLE
Rename dir>path

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,8 +105,8 @@ module.exports = function (opts, callback) {
   }
 }
 
-function packageFiles (dir) {
-  return packlist.sync({ dir }).filter(function (fp) {
+function packageFiles (path) {
+  return packlist.sync({ path }).filter(function (fp) {
     return !/^prebuilds[/\\]/i.test(fp)
   })
 }
@@ -123,6 +123,9 @@ function prebuildifyArgv (argv, image) {
 
   for (let i = 0; i < argv.length - 1; i++) {
     if (/^(-i|--image)$/.test(argv[i]) && argv[i + 1][0] !== '-') {
+      argv.splice(i--, 2)
+    }
+    if (/^(--cwd)$/.test(argv[i]) && argv[i + 1][0] !== '-') {
       argv.splice(i--, 2)
     }
   }


### PR DESCRIPTION
This PR fixes 2 issues:

- Packlist expects an [option named `path`](https://github.com/npm/npm-packlist/blob/main/index.js#L82) for the working directory, not `dir`
- Removed `cwd` from the args passed to `prebuildify` when specified