### PR TITLE
feat: added support for custom node_modules path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ prebuildify-cross -i centos7-devtoolset7 -t 8.14.0 --napi --strip
 To build for more than one platform, multiple `--image` arguments may be passed:
 
 ```
-prebuildify-cross -i linux-armv7 -i linux-arm64 -t ..
+prebuildify-cross
 ```
 
 By default [`prebuild/docker-images`](https://github.com/prebuild/docker-images) are used which are publicly hosted on the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`). It's possible to use custom images with e.g. `-i my-namespace/my-image`. Image arguments that don't contain a forward slash are expanded to `ghcr.io/prebuild/<image>` and if these don't contain a tag they're further expanded to `ghcr.io/prebuild/<image>:<version>` where `version` is currently 2.
@@ -32,6 +32,12 @@ To use `latest` images (not recommended) an image tag must be specified explicit
 
 ```
 prebuildify-cross -i linux-armv7:latest -t ..
+```
+
+Set a custom node_modules path:
+
+```sh
+prebuildify-cross --nodemodulespath ../../node_modules -i linux-armv7:latest -t 20.0.0 --strip
 ```
 
 ## Images

--- a/cli.js
+++ b/cli.js
@@ -4,8 +4,8 @@
 const argv = process.argv.slice(2)
 
 const opts = require('minimist')(argv, {
-  string: ['image', 'cwd'],
-  alias: { image: 'i' }
+  string: ['image', 'cwd', 'nodemodulespath'],
+  alias: { image: 'i'}
 })
 
 require('.')({ argv, ...opts }, function (err) {

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = function (opts, callback) {
 
   const images = [].concat(opts.image || [])
   const cwd = path.resolve(opts.cwd || '.')
+  const nodeModulesPath = opts.nodemodulespath ? path.resolve(opts.nodemodulespath) : null;
+
   const files = JSON.stringify(packageFiles(cwd))
   const prebuilds = path.join(cwd, 'prebuilds')
   const log = logger.create(process.stderr, { showCursor: true })
@@ -70,13 +72,19 @@ module.exports = function (opts, callback) {
     console.error('> prebuildify-cross run %s', image)
     console.error('> prebuildify %s\n', argv.join(' '))
 
+    const volumes = {
+      // Should but can't use :ro (mafintosh/docker-run#12)
+      [cygwin(cwd)]: '/input',
+    };
+
+    if (nodeModulesPath) {
+      volumes[nodeModulesPath] = '/input/node_modules';
+    }
+
     const child = dockerRun(image, {
       entrypoint: 'node',
       argv: ['-'].concat(argv),
-      volumes: {
-        // Should but can't use :ro (mafintosh/docker-run#12)
-        [cygwin(cwd)]: '/input'
-      },
+      volumes,
       env: {
         PREBUILDIFY_CROSS_FILES: files,
         // Disable npm update check
@@ -126,6 +134,9 @@ function prebuildifyArgv (argv, image) {
       argv.splice(i--, 2)
     }
     if (/^(--cwd)$/.test(argv[i]) && argv[i + 1][0] !== '-') {
+      argv.splice(i--, 2)
+    }
+    if (/^(--nodemodulespath)$/.test(argv[i]) && argv[i + 1][0] !== '-') {
       argv.splice(i--, 2)
     }
   }


### PR DESCRIPTION
closes #18

Manually tested. Works great

> $ npx prebuildify-cross ---nodemodulespath ../../node_modules i centos7-devtoolset7 -t node@14.0.0 -t node@16.0.0 -t node@18.0.0 -t node@20.0.0 -t node@21.0.0 --strip


